### PR TITLE
Keywords definition set in separated parameters

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11"]
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
@@ -20,4 +20,4 @@ jobs:
         pip install pylint
     - name: Analysing the code with pylint
       run: |
-        pylint $(git ls-files '*.py')
+        pylint $(git ls-files '*.py') --max-line-length 120 -E

--- a/chksecret/secret_patterns.py
+++ b/chksecret/secret_patterns.py
@@ -1,20 +1,28 @@
 #!/usr/bin/python3
+"""
+Defines regular expression patterns to match secret codes or private keys
+"""
+# Reserved keywords to match in patterns
+_RESERVED_K_ = "SCC_REGCODE|AUTH_TOKEN|password|secret|private|api_key|token|private_key"
 
-# Defines a regular expression pattern to match secret codes or private keys
+# Personal keywords to match in patterns
+_PERSONAL_K_ = "email|home_address|sex|race"
+
+# list of regular expression to match secret codes or private keys
 __secret_patterns__ = [
-    # enabled, pattern, print-message
-    [0, r'(\s*=\s*)[\"\']RSA-([0-9]+)',
-        "potential RSA code"],
-    [1, r'(\s*=\s*)[\'\"]AES-([0-9]+)',
-        "potential AES code"],
-    [1, r'\s*(?:my|our)\s*[a-zA-Z_]*[a-zA-Z0-9_]*(SCC_REGCODE|AUTH_TOKEN|passwd|password|secret|private|api_key|token|ssh_private_key)[a-zA-Z0-9_]*\s*[=]?',
-        "variables with potential secret keywords"],
-    [1, r'\s*[=]?\s*[a-zA-Z0-9_-]*(SCC_REGCODE|AUTH_TOKEN|passwd|password|secret|private|api_key|token|ssh_private_key)[a-zA-Z0-9_-]*\s*[=]?',
-        "pattern matching potential reserved keywords"],
-    [1, r'\s*(?:my|our)\s*[a-zA-Z_]*[a-zA-Z0-9_\.]*(email|home_address)[a-zA-Z0-9_\.]*\s*[=]?', 
-        "variables with potential privacy-sensible keywords"],
-    [1, r'\s*[=]?\s*[\.a-zA-Z0-9_-]*(email|home_address)[\.a-zA-Z0-9_-]*\s*[=]?', 
-        "pattern matching potential privacy-sensible keywords"],
-    [1, r'\s*[=]?[a-zA-Z0-9._%+-]+[@][a-zA-Z0-9._-]+[\.][a-zA-Z]{2,}\s*', 
-        "pattern matching potential personal email address"],
+  # field desc.: enabled[0/1], pattern[regexp], alert-message[text]
+  [0, r'(\s*=\s*)[\"\']RSA-([0-9]+)',
+      "potential RSA code"],
+  [1, r'(\s*=\s*)[\"\']AES-([0-9]+)',
+      "potential AES code"],
+  [0, r'\s*(?:my|our)\s*[a-zA-Z_]*[a-zA-Z0-9_]*'+r"("+_RESERVED_K_+")"+r'[a-zA-Z0-9_]*\s*[=]?',
+      "variables with potential secret keywords"],
+  [1, r'\s*[=]?\s*[a-zA-Z0-9_-]*'+r"("+_RESERVED_K_+")"+r'[a-zA-Z0-9_-]*\s*[=]?',
+      "pattern matching potential reserved keywords"],
+  [1, r'\s*(?:my|our)\s*[a-zA-Z_]*[a-zA-Z0-9_\.]*'+r"("+_PERSONAL_K_+")"+r'[a-zA-Z0-9_\.]*\s*[=]?',
+      "variables with potential privacy-sensible keywords"],
+  [1, r'\s*[=]?\s*[\.a-zA-Z0-9_-]*'+r"("+_PERSONAL_K_+")"+r'[\.a-zA-Z0-9_-]*\s*[=]?',
+      "pattern matching potential privacy-sensible keywords"],
+  [1, r'\s*[=]?[a-zA-Z0-9._%+-]+[@][a-zA-Z0-9._-]+[\.][a-zA-Z]{2,}\s*',
+      "pattern matching potential personal email address"],
 ]

--- a/chksecret/tests/test1.pl
+++ b/chksecret/tests/test1.pl
@@ -3,7 +3,7 @@ use strict;
 use Data::Dumper;
 
 my $a;
-my $b = 012p.axy@beta.com;
+my $b = "_012p.ax.y@beta.abc.com";
 my $c; ## my password to remember it is xxx
 my %h = ( blue => 11, red => 22 );
 


### PR DESCRIPTION
This PR is needed to fix pylint warnings, raised after it've been added to workload.

Followup of PR#1.

In the match-patterns the keywords are now imported from previous defined parameters: syntax fixed.

pylint rules fixed: chks from v3.9 to 3.11, --max-line-length 120, -E


